### PR TITLE
feat: remove skip flag for zokrates 0.8.0

### DIFF
--- a/lib/compile.js
+++ b/lib/compile.js
@@ -21,7 +21,7 @@ async function compile(
   curve = 'bn128',
   options = {},
 ) {
-  const { maxReturn = 10000000, verbose = false } = options;
+  const { maxReturn = 10000000, verbose = false, skipLightFlag = false } = options;
   if (!fs.existsSync(codePath)) {
     throw new Error('Compile input file(s) not found');
   }
@@ -29,18 +29,21 @@ async function compile(
   // TODO: Check if outputPath is directory, otherwise throw.
   const parsedOutputPath = outputPath.endsWith('/') ? outputPath : `${outputPath}/`;
   return new Promise((resolve, reject) => {
+    const compileOptions = [
+      'compile',
+      '-i',
+      codePath,
+      '-o',
+      `${parsedOutputPath}${parsedOutputName}`,
+      '--curve',
+      curve,
+    ];
+
+    if (!skipLightFlag) compileOptions.push('--light');
+
     const zokrates = spawn(
       '/app/zokrates',
-      [
-        'compile',
-        '-i',
-        codePath,
-        '-o',
-        `${parsedOutputPath}${parsedOutputName}`,
-        '--curve',
-        curve,
-        '--light',
-      ],
+      compileOptions,
       {
         stdio: ['ignore', 'pipe', 'pipe'],
         env: {


### PR DESCRIPTION
### Description

Added an option to skip the `--light` on the `compile` function, since it is no longer supported on `ZoKrates 0.8.0`.

### Checklist

- [x] I have reviewed the code changes myself
- [x] My code meets all of the acceptance criteria of the ticket it closes.
- [x] I have removed unused code (e.g., `console.logs`, commented out blocks, etc.)
- [x] I have made all necessary changes to the documentation.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] Any dependent changes have been merged and published.
